### PR TITLE
Update Base image version, so that installing curl 8.5 with apk is po…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.17.10-alpine
+FROM nginx:1.21-alpine
 
 EXPOSE 8000
 CMD ["/sbin/entrypoint.sh"]
@@ -54,6 +54,8 @@ RUN apk add --no-cache --update \
     wget sqlite git curl bash grep \
     supervisor
 
+# upgrade curl to address CVE-2023-38545 and liburl as dependency
+RUN apk upgrade --no-cache --update -U libcurl curl
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
     ln -sf /dev/stderr /var/log/nginx/error.log && \


### PR DESCRIPTION
# Description
Update Base image version, so that installing curl 8.5 with apk is possible, which addresses CVE-2023-38545

<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.